### PR TITLE
Updates Docs (CoC) to with a touch more gracious responses in the examples.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ Sometimes, though, you need to get maintainers involved. Maintainers will do the
 
 > Patt: "I'm not attacking anyone, what's your problem?"
 
-> Alex: "@maintainers hey uh. Can someone look at this issue? Patt is getting a bit aggro. I tried to nudge them about it, but nope."
+> Alex: "@maintainers hey uh. Can someone look at this issue? Patt is being rather rude. I tried to nudge them about it, but they didn't listen or understand."
 
 > KeeperOfCommitBits: (on issue) "Hey Patt, maintainer here. Could you tone it down? This sort of attack is really not okay in this space."
 
@@ -134,7 +134,7 @@ Sometimes, though, you need to get maintainers involved. Maintainers will do the
 
 > Patt: "NOOOOPE. OH NOPE NOPE."
 
-> Alex: "JFC NO. NOPE. @keeperofbits NOPE NOPE LOOK HERE"
+> Alex: "OH DEAR, NO. NOPE. @keeperofbits NOPE NOPE LOOK HERE"
 
 > KeeperOfCommitBits: "👀 Nope. NOPE NOPE NOPE. 🔥"
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -134,7 +134,7 @@ Sometimes, though, you need to get maintainers involved. Maintainers will do the
 
 > Patt: "NOOOOPE. OH NOPE NOPE."
 
-> Alex: "OH DEAR, NO. NOPE. @keeperofbits NOPE NOPE LOOK HERE"
+> Alex: "ABSOLUTELY NOT, NO. NOPE. @keeperofbits NOPE NOPE LOOK HERE"
 
 > KeeperOfCommitBits: "👀 Nope. NOPE NOPE NOPE. 🔥"
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ Sometimes, though, you need to get maintainers involved. Maintainers will do the
 
 > Patt: "I'm not attacking anyone, what's your problem?"
 
-> Alex: "@maintainers hey uh. Can someone look at this issue? Patt is being rather rude. I tried to nudge them about it, but they didn't listen or understand."
+> Alex: "@maintainers hey uh. Can someone look at this issue? Patt is getting a bit aggro. I tried to nudge them about it, but nope."
 
 > KeeperOfCommitBits: (on issue) "Hey Patt, maintainer here. Could you tone it down? This sort of attack is really not okay in this space."
 


### PR DESCRIPTION
I absolutely love these examples. They bring so much context and thought to the codified order of elevation. I added these two small changes to remove "JCF" reference and to a bit more gracious in the face of someone being ridiculous.

I came here from the healthy comments in [Discussion: CoC Violations & Accountability](https://github.com/nodejs/community-committee/issues/111#issuecomment-323868882)